### PR TITLE
Add shebang line to scripts.

### DIFF
--- a/bin/lottie_common.sh
+++ b/bin/lottie_common.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/sh
 # this is common source file used by lottie_to_gif.sh, lottie_to_webp.sh
 # required bash variables
 # $HEIGHT

--- a/bin/lottie_to_apng.sh
+++ b/bin/lottie_to_apng.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/sh
 HEIGHT=512
 WIDTH=512
 FPS=60

--- a/bin/lottie_to_gif.sh
+++ b/bin/lottie_to_gif.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/sh
 HEIGHT=512
 WIDTH=512
 FPS=50

--- a/bin/lottie_to_png.sh
+++ b/bin/lottie_to_png.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/sh
 HEIGHT=512
 WIDTH=512
 FPS=60

--- a/bin/lottie_to_webm.sh
+++ b/bin/lottie_to_webm.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/sh
 HEIGHT=512
 WIDTH=512
 FPS=60

--- a/bin/lottie_to_webp.sh
+++ b/bin/lottie_to_webp.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/sh
 HEIGHT=512
 WIDTH=512
 FPS=60


### PR DESCRIPTION
This prevents an error when running the scripts from python: `OSError: [Errno 8] Exec format error: 'lottie_to_webm.sh'`